### PR TITLE
Fixed setting p0 for HW and FW

### DIFF
--- a/test/TestPressure.m
+++ b/test/TestPressure.m
@@ -23,22 +23,22 @@ classdef TestPressure < matlab.unittest.TestCase
             
             % case t < h, p_res_mode = 'same', p_fault = 'min', diffusion=0
             p = Pressure(tc.ensemble{1}, tc.load_table, tc);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0, "RelTol", 1e-10);
             
             % set dp fault to max(dp_Hw, dp_FW)
             tc.dp_fault_mode = 'max';
             tc.generate_ensemble;
             p = Pressure(tc.ensemble{1}, tc.load_table, tc);
           
-            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0, "RelTol", 1e-10);
             
             % single side scenario
             tc.dp_fault_mode = 'min';
@@ -47,11 +47,11 @@ classdef TestPressure < matlab.unittest.TestCase
             tc.generate_ensemble;
             p = Pressure(tc.ensemble{1}, tc.load_table, tc);
             
-            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0, "RelTol", 1e-10);
 
             % single side scenario
             tc.p_fault_mode = 'min';
@@ -60,11 +60,11 @@ classdef TestPressure < matlab.unittest.TestCase
             tc.generate_ensemble;
             p = Pressure(tc.ensemble{1}, tc.load_table, tc);
             
-            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), -1);
-            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0);
-            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_res, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_base, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.res_seal, end), -1, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.base_base, end), 0, "RelTol", 1e-10);
+            testCase.verifyEqual(p.dp_fault(i_mid.seal_seal, end), 0, "RelTol", 1e-10);
 
              % dp_HW = p.get_HW_pressure_change();
              % dp_FW = p.get_FW_pressure_change();
@@ -91,6 +91,35 @@ classdef TestPressure < matlab.unittest.TestCase
             p_at_eval = interp1(tc.y, p.p(:,end), y_eval);
 
             testCase.verifyEqual(p_at_eval, 31.0805, "RelTol", 0.05);
+        end
+
+        function test_initial_pressures(testCase)
+            % default case
+            tc = PantherInput;
+            tc.load_table = tc.load_table(1:2,:);
+            tc.load_table.time_steps(2) = 1;
+            tc.load_table.P_steps(2) = -1;
+            tc.diffusion_P = 1;
+            tc.input_parameters.p_grad_res.value = 0.2;
+            tc.dp_fault_mode = 'min';
+            tc.p_fault_mode = 'max';
+            tc.generate_ensemble();
+            
+            % case t < h, p_res_mode = 'same', dp_fault_mode = 'min', diffusion =
+            % 1, p_fault_mode = 'max'
+            % initial pressure should be equal to pressure computed at t =
+            % 0 (sanity checks, pressures at t=0 should be equal, dp should be 0)
+            p = Pressure(tc.ensemble{1}, tc.load_table, tc);
+            p_HW = p.get_HW_pressure();
+            p0_HW = p.get_HW_p0();
+            p_HW_diff = p_HW(:,1) - p0_HW;
+            testCase.verifyEqual(max(abs(p_HW_diff)), 0, "RelTol", 1e-10);
+            dp_HW = p.get_HW_pressure_change();
+            testCase.verifyEqual(max(abs(dp_HW(:,1))), 0, "RelTol", 1e-10);
+            dp_FW = p.get_FW_pressure_change();
+            testCase.verifyEqual(max(abs(dp_FW(:,1))), 0, "RelTol", 1e-10);
+            dp_fault = p.dp_fault;
+            testCase.verifyEqual(max(abs(dp_fault(:,1))), 0, "RelTol", 1e-10);
         end
         
 


### PR DESCRIPTION
Some functions called on p0 whereas they should have called on po for HW or FW
Now made separate methods for get_FW_p0 and get_HW_p0 to make the code clearer
And added a test for the initial pressures