### PR TITLE
Added function to extract along fault length to ModelGeometry

### DIFF
--- a/src/calculator/ModelGeometry.m
+++ b/src/calculator/ModelGeometry.m
@@ -138,6 +138,16 @@ classdef (HandleCompatible) ModelGeometry
                 error('Incorrect side indicator entered, should be FW or HW');
             end
         end
+
+        function [L] = get_along_fault_length(self, y)
+            % Obtains the length along the fault, with 0 being the mid
+            % depth (y=0)
+            % Input:
+            %   y - Depth values
+            % Output
+            %   L - Along-fault length
+            L = y / sin(self.dip * pi/ 180);
+        end
         
      
     end


### PR DESCRIPTION
Returns along-fault length L, w.r.t. the model center depth